### PR TITLE
Specify product type as .dynamic

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,6 +11,7 @@ let package = Package(
     products: [
         .library(
             name: "fusion",
+            type: .dynamic,
             targets: ["fusion"]),
     ],
     dependencies: [


### PR DESCRIPTION
This PR explicitly specifies product type as `.dynamic` library to prevent code duplication when it's linked with other dynamic libraries. Apple strongly recommends not to link static libraries with dynamic frameworks.